### PR TITLE
docs: add plugin description and action summary to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-# Clocks
+# Battery
+
+A StreamController plugin for monitoring battery levels on Linux devices.
+
+## Actions
+
+### Battery Percentage
+Displays the battery percentage of a selected device on your Stream Deck with a visual indicator that shows charging status and color-coded warnings (red for low battery, green for full).


### PR DESCRIPTION
## Summary

- Updated README.md to include a comprehensive description of the Battery plugin
- Added documentation for the Battery Percentage action with a one-sentence summary of its functionality
- Replaced the placeholder "Clocks" title with accurate Battery plugin information

## Changes

The README previously contained only "# Clocks" as a placeholder. This PR adds:
- Plugin description explaining it monitors battery levels on Linux devices
- Actions section documenting the Battery Percentage action
- Details about the action's features including device selection, percentage display, charging status indicators, and color-coded warnings

This improves the plugin's documentation to help users understand what the Battery Percentage action does at a glance.